### PR TITLE
[Feature] add page to display all transaction history

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 
 import Balance from "./component/Balance";
 import IncomeExpense from "./component/IncomeExpense";
-import TransactionHistory from "./component/TransactionHistory";
+import TransactionHistoryGlance from "./component/TransactionHistoryGlance";
 import Glance from "./component/Glance";
 import { NavBar } from "./component/NavBar";
 import SpendingGraph from "./component/SpendingGraph";
@@ -52,7 +52,7 @@ function App() {
             <IncomeExpense/>
             <div className="flex flex-col lg:flex-row w-full items-center lg:items-end lg:justify-center md:mt-16">
                 <Glance type="stock"/>
-                <TransactionHistory transactionhistory="List of transactions" sync={sync}/>
+                <TransactionHistoryGlance sync={sync}/>
                 <Glance type="crypto"/>
             </div>
             <SpendingGraph/>

--- a/client/src/TransactionHistory.jsx
+++ b/client/src/TransactionHistory.jsx
@@ -1,0 +1,130 @@
+import "./App.css";
+
+import { useState, useEffect } from "react";
+import { NavBar } from "./component/NavBar";
+
+import { NotificationType, useNotificationContext } from "./component/Notification";
+import { request } from "./utils/Fetch";
+import { formatMoney, formatDate } from "./utils/utils";
+
+function TransactionHistory() {
+    const [transactions, setTransactions] = useState([]);
+    const [filter, setFilter] = useState({ name: "", amount: "", date: "", category: "", assetType: "", currency: "" });
+    const { display: displayNotification } = useNotificationContext();
+
+    useEffect(() => {
+        request({
+            url: "/api/transactions",
+            method: "GET",
+            callback: ({ msg, success, json }) => {
+                if (success) {
+                    setTransactions(json);
+                } else {
+                    displayNotification({ message: "Unable to get transaction history: " + msg, type: NotificationType.Error });
+                }
+            }
+        });
+    }, []);
+
+    const updateFilter = (e) => setFilter({ ...filter, [e.target.name]: e.target.value });
+
+    const filterTransactions = transaction => {
+        const straightMatchKeys = ["name", "amount", "category", "assetType", "currency"];
+        for (let i = 0; i < straightMatchKeys.length; i++) {
+            if (filter[straightMatchKeys[i]].trim() === "") {
+                continue;
+            }
+
+            if (!String(transaction[straightMatchKeys[i]]).toLowerCase().includes(filter[straightMatchKeys[i]].toLowerCase())) {
+                return false;
+            }
+        }
+
+        if (filter.date.trim() === "") {
+            return true;
+        }
+
+        return formatDate(transaction.date).includes(filter.date);
+    };
+
+    const sortTransactions = (a, b) => new Date(b.date) - new Date(a.date);
+
+    // TODO: add a delete button per row
+    const transactionHistoryTemplate = () => {
+        return (
+            <div className="overflow-y-scroll overflow-x-scroll w-full">
+                <table className="text-left table-auto w-full text-lg border-2 border-slate-800">
+                    <thead>
+                        <tr className="bg-slate-800">
+                            <th className="px-4 py-2 w-2/6">Name</th>
+                            <th className="px-4 py-2 text-right w-1/6">Amount</th>
+                            <th className="px-4 py-2">Date</th>
+                            <th className="px-4 py-2 w-1/6">Category</th>
+                            <th className="px-4 py-2">Asset Type</th>
+                            <th className="px-4 py-2 text-right">Currency</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr className="border-1 border-slate-800">
+                            <td className="px-4 py-2">
+                                <input placeholder="Filter by name" value={filter.name} onChange={updateFilter} name="name" className="w-full"/>
+                            </td>
+                            <td className="px-4 py-2 text-right">
+                                <input placeholder="Filter by amount" value={filter.amount}
+                                    onChange={updateFilter} name="amount" className="w-full text-right"/>
+                            </td>
+                            <td className="px-2 py-2">
+                                <input placeholder="Filter by date" value={filter.date} onChange={updateFilter} name="date" className="w-full"/>
+                            </td>
+                            <td className="px-4 py-2">
+                                <input placeholder="Filter by category" value={filter.category} onChange={updateFilter}
+                                    name="category" className="w-full"/>
+                            </td>
+                            <td className="px-2 py-2">
+                                <input placeholder="Filter by asset type" value={filter.assetType} onChange={updateFilter} name="assetType"/>
+                            </td>
+                            <td className="px-4 py-2 text-right">
+                                <input placeholder="Filter by currency" value={filter.currency} onChange={updateFilter}
+                                    name="currency" className="text-right"/>
+                            </td>
+                        </tr>
+                        { transactions
+                            .filter(filterTransactions)
+                            .sort(sortTransactions)
+                            .map((transaction, i) => (
+                                <tr key={i} className="hover:bg-slate-700">
+                                    <td className="px-4 py-2">{transaction.name}</td>
+                                    <td id={"transaction-history-amount-" + i}
+                                        className={"px-2 py-2 text-right " + (transaction.amount < 0 ? "text-red-400": "text-green-400")}>
+                                        {/* add symbol */} {transaction.assetType === "cash" ? formatMoney(transaction.amount) : transaction.amount}
+                                    </td>
+                                    <td className="px-2 py-2 text-orange-300">{formatDate(transaction.date)}</td>
+                                    <td className="px-4 py-2 text-sky-400">{transaction.category}</td>
+                                    <td className="px-2 py-2">{transaction.assetType}</td>
+                                    <td className="px-2 py-2 text-right">{transaction.currency}</td>
+                                </tr>
+                            ))
+                        }
+                    </tbody>
+                </table>
+            </div>
+        );
+    };
+
+    return (
+        <div className="place-items-center bg-slate-900 min-h-screen text-gray-300 md:px-4 w-full">
+            <NavBar/>
+
+            {/* TODO: paginate? */}
+            {/* TODO: make this table mobile friendly? */}
+            {
+                transactions.length > 0 ? transactionHistoryTemplate() :
+                    <div className="w-full h-full flex flex-col items-center">
+                        <span id="no-transactions-found" className="text-2xl font-bold text-gray-200">No transactions found.</span>
+                    </div>
+            }
+        </div>
+    );
+}
+
+export default TransactionHistory;

--- a/client/src/component/NavBar.jsx
+++ b/client/src/component/NavBar.jsx
@@ -6,8 +6,8 @@ export const NavBar = () => {
     const navlinks = [
         {
             id: 1,
-            name: "Balance",
-            route: "#balance"
+            name: "Home",
+            route: "/"
         },
         {
             id: 2,
@@ -17,7 +17,7 @@ export const NavBar = () => {
         {
             id: 3,
             name: "History",
-            route: "#history"
+            route: "/history"
         },
         {
             id: 4,

--- a/client/src/component/TransactionHistoryGlance.jsx
+++ b/client/src/component/TransactionHistoryGlance.jsx
@@ -6,7 +6,7 @@ import { request } from "../utils/Fetch";
 
 const MAX_TRANSACTION_ITEMS = 5;
 
-const TransactionHistory = ({ sync }) => {
+const TransactionHistoryGlance = ({ sync }) => {
     const [transactions, setTransactions] = useState([]);
 
     const { display: displayNotification } = useNotificationContext();
@@ -33,7 +33,7 @@ const TransactionHistory = ({ sync }) => {
         <section id="history" className="flex flex-col p-4 mx-4 bg-gray-800 rounded-md w-full md:w-fit my-4 md:my-2 h-fit lg:h-1/3">
             <div className="flex flex-col lg:flex-row lg:justify-between lg:items-end mb-4">
                 <div className="mt-2 text-stone-200 text-2xl font-semibold capitalize mb-2 lg:mb-0">Transaction History</div>
-                <a href="" className="font-semibold text-sky-400 hover:text-sky-600">View all</a>
+                <a href="/history" className="font-semibold text-sky-400 hover:text-sky-600">View all</a>
             </div>
             <div id="transaction-history-list">{
                 transactions
@@ -45,4 +45,4 @@ const TransactionHistory = ({ sync }) => {
     );
 };
 
-export default TransactionHistory;
+export default TransactionHistoryGlance;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import "./index.css";
 import App from "./App.jsx";
+import TransactionHistory from "./TransactionHistory";
 import Error from "./Error";
 
 import { Notification, NotificationProvider } from "./component/Notification";
@@ -13,6 +14,11 @@ const router = createBrowserRouter([
     {
         path: "/",
         element: <App />,
+        errorElement: <Error />,
+    },
+    {
+        path: "/history",
+        element: <TransactionHistory />,
         errorElement: <Error />,
     }
 ]);

--- a/integration/home.spec.js
+++ b/integration/home.spec.js
@@ -126,7 +126,7 @@ test.describe("index cards", () => {
     });
 });
 
-test.describe("transaction history", () => {
+test.describe("transaction history glance", () => {
     test("transaction section should contain no items if no transactions", async ({ page }) => {
         await pageSetup({ page });
 

--- a/integration/transactionHistory.spec.js
+++ b/integration/transactionHistory.spec.js
@@ -1,0 +1,103 @@
+// @ts-check
+import { test, expect } from "@playwright/test";
+
+import { pageSetup } from "./setup";
+
+test.afterEach(async () => {
+    // TODO: if this were running as an "integration" test, we'd need to not run this (or mock it)
+    await fetch("http://localhost:5000/api/admin/wipeDb"); // TODO: extract url
+});
+
+test("has title", async ({ page }) => {
+    await pageSetup({ page });
+
+    await expect(page.locator("[data-test-id=\"header-title\"]")).toHaveText(/Finance Tracker/);
+});
+
+// TODO: extract to helper?
+const addTransaction = async (page, value, assetType="cash", currency="eur", date, name="Test Transaction",) => {
+    const addTransactionButton = page.locator("#add-transaction-button");
+
+    await addTransactionButton.click();
+    await page.locator("#transaction-name").fill(name);
+    await page.locator("#transaction-amount").fill(value);
+    await page.locator("#transaction-category").selectOption({ value: "other" });
+    await page.locator("#transaction-asset-type").selectOption({ value: assetType });
+    await page.locator("#transaction-currency").selectOption({ value: currency });
+    if (date) {
+        await page.locator("#transaction-date").fill(date);
+    }
+    await page.locator("#submit-transaction").click();
+};
+
+test.describe("transaction history", () => {
+    test("transaction history page should contain no items if no transactions", async ({ page }) => {
+        await pageSetup({ page, pathname:"/history" });
+
+        await expect(page.locator("#no-transactions-found")).toBeVisible();
+        await expect(page.locator("#no-transactions-found")).toHaveText("No transactions found.");
+    });
+
+    test("transaction history page should contain the appropriate number of items based transactions", async ({ page }) => {
+        await pageSetup({ page });
+
+        await addTransaction(page, "10", "crypto", "BTC");
+        await addTransaction(page, "-50", "crypto", "ETH");
+        await addTransaction(page, "-20", "crypto", "ADA");
+        await addTransaction(page, "10");
+        await addTransaction(page, "50");
+
+        await pageSetup({ page, pathname:"/history" });
+
+        await expect(page.locator("tr")).toHaveCount(7);
+    });
+
+    test("transaction history page should contain the transactions sorted with the most recent first", async ({ page }) => {
+        await pageSetup({ page });
+
+        await addTransaction(page, "10", "crypto", "BTC", "2022-01-07T23:43:09");
+        await addTransaction(page, "-40", "crypto", "ETH", "2023-01-07T23:43:09");
+        await addTransaction(page, "-80", "crypto", "ADA", "2024-01-07T23:43:09");
+        await addTransaction(page, "10", "cash", "eur", "2025-01-07T23:43:09");
+        await addTransaction(page, "-50", "cash", "usd", "2025-02-07T23:43:09");
+        await addTransaction(page, "-20", "cash", "cad", "2025-02-08T23:43:09");
+
+        await pageSetup({ page, pathname:"/history" });
+        const items = page.locator("tr");
+
+        // first item in the table should be the most recent
+        await expect(items.nth(2).locator("#transaction-history-amount-0")).toHaveText(/-\s*20\.00/);
+
+        // last item in the table should be the oldest
+        await expect(items.last().locator("#transaction-history-amount-5")).toHaveText(/\s*10/);
+    });
+
+    test("transaction history page should allow filtering by transaction name", async ({ page }) => {
+        await pageSetup({ page });
+
+        await addTransaction(page, "10", "crypto", "BTC", "2022-01-07T23:43:09", "Test Transaction 1");
+        await addTransaction(page, "-40", "crypto", "ETH", "2023-01-07T23:43:09", "Deposit");
+        await addTransaction(page, "-80", "crypto", "ADA", "2024-01-07T23:43:09", "Credit Dividend");
+        await addTransaction(page, "10", "cash", "eur", "2025-01-07T23:43:09", "Credit Card Payment");
+        await addTransaction(page, "-50", "cash", "usd", "2025-02-07T23:43:09", "Withdrawal");
+        await addTransaction(page, "-20", "cash", "cad", "2025-02-08T23:43:09", "Test Transaction 2");
+
+        await pageSetup({ page, pathname:"/history" });
+        await expect(page.locator("tr")).toHaveCount(8);
+
+        const nameFilter = page.locator("input[name=name]");
+        await nameFilter.fill("Depo");
+        await expect(page.locator("tr")).toHaveCount(3);
+
+        await nameFilter.clear();
+        await expect(page.locator("tr")).toHaveCount(8);
+
+        nameFilter.fill("credit");
+        await expect(page.locator("tr")).toHaveCount(4);
+
+        const dateFilter = page.locator("input[name=date]");
+        dateFilter.fill("2025");
+
+        await expect(page.locator("tr")).toHaveCount(3);
+    });
+});


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] Searched for similar existing [pull requests](https://github.com/JChris246/financial_tracker/pulls)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] Covered the code with tests that prove my fix is effective or that my feature works (note that PRs
without tests will likely be REJECTED)
- [x] New and existing tests pass locally with my changes

---

### What is the purpose of your *pull request*?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of your *pull request* and other information

This PR adds a page to display all the transactions (home page displays only 5). The table allows filtering by all fields of the transaction. 

## How Has This Been Tested?

Automation tests were added.

Manual testing:

- Run the app in dev mode
- Add transaction on the home page.
- Navigate to the transaction history page,
  - directly by entering in the address bar `http://localhost:5173/history`
  - by clicking view all on the transaction preview component on the home page
  - by clicking history tab in the navbar
 - Verify that all added transactions are displayed and can be filtered


## Screenshots (if appropriate):

<img width="2487" height="616" alt="image" src="https://github.com/user-attachments/assets/34fb3880-f0f2-482d-8903-a8ced0f96950" />

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/c6eb530b-5a68-43f1-b876-b721e8523f00" />

