### PR TITLE
[Feature] support markdown table for importing transactions

### DIFF
--- a/client/src/component/AddTransaction.jsx
+++ b/client/src/component/AddTransaction.jsx
@@ -81,10 +81,22 @@ export const AddTransaction = ({ refresh }) => {
     const selectFile = async e => {
         const { target: { files } } = e;
 
+        const extension = files[0]?.name?.split(".").slice(-1)[0];
+        if (!extension) {
+            // not all OSes force file extensions, but we need it to determine how to process (apart from reading the byte headers)
+            displayNotification({ message: "Unknown file extension", type: NotificationType.Error });
+            return;
+        }
+
+        if (extension !== "csv" && extension !== "md") {
+            displayNotification({ message: "File does not seem to be a md or csv", type: NotificationType.Error });
+            return;
+        }
+
         request({
-            url: "/api/transaction/csv",
+            url: "/api/transaction/" + extension,
             method: "POST",
-            body: JSON.stringify({ csv: await files[0].text() }),
+            body: JSON.stringify({ [extension]: await files[0].text() }),
             callback: ({ json, status }) => {
                 if (status !== 500) {
                     const { transactions, invalid } = json;
@@ -271,9 +283,9 @@ export const AddTransaction = ({ refresh }) => {
         });
     };
 
-    const reviewCsvTemplate = () => {
+    const reviewTransactionsTemplate = () => {
         return (
-            <div id="review-csv-modal" className="flex flex-col w-full h-full rounded-none lg:w-2/3 xl:w-fit md:h-fit bg-slate-900 border-2
+            <div id="review-transactions-modal" className="flex flex-col w-full h-full rounded-none lg:w-2/3 xl:w-fit md:h-fit bg-slate-900 border-2
                 border-slate-800 md:rounded-lg shadow-lg outline-none focus:outline-none">
                 <div className="flex items-end justify-between p-5 border-b-1 border-solid rounded-t border-slate-800 mb-2">
                     <h3 className="text-3xl font-semibold">Review Transactions</h3>
@@ -396,7 +408,7 @@ export const AddTransaction = ({ refresh }) => {
                             1.125-1.125V11.25a10 9 0 0 0-9-9Z" />
                     </svg>
                 </button>
-                <input type="file" accept=".csv" id="csv-file-input" className="hidden" onChange={selectFile} ref={csvInput} />
+                <input type="file" accept=".csv,.md" id="transactions-file-input" className="hidden" onChange={selectFile} ref={csvInput} />
             </div>
 
             {isAddTransactionModalOpen && <Modal close={closeAddTransactionModal}>
@@ -404,7 +416,7 @@ export const AddTransaction = ({ refresh }) => {
             </Modal> }
 
             {isCSVModalOpen && <Modal close={closeReviewCsvModal}>
-                { reviewCsvTemplate() }
+                { reviewTransactionsTemplate() }
             </Modal> }
 
         </section>

--- a/integration/bad_transactions.md
+++ b/integration/bad_transactions.md
@@ -1,0 +1,9 @@
+| name                                    | date       | amount  | assetType | currency | category |
+| --------------------------------------- | ---------- | ------- | --------- | -------- | -------- |
+| Descriptive Deposit Subscription Rebate | 2024-03-02 | 10.00   | cash      | usd      | other    |
+| Descriptive Deposit CC Cashback Rebate  | 2024-03-02 | 6.77    | cash      | usd      | other    |
+| ACH Deposit APPL - EDIPAYMENT           | 2024-03-15 | 2171.45 | cash      | usd      | income   |
+| ACH Deposit IRS TREAS 310 - TAX REF     | 2024-03-27 | 138.00  | cash      | usd      | other    |
+| ACH Deposit APPL - EDIPAYMENT           | 2024-03-29 | 2171.43 | cash      | usd      | income   |
+| Credit Dividend                         | 2024-03-31 | 0.09    | cash      | usd      | other    |
+|                                         | 2024-03-31 | 10.09   | cash      | usd      | other    |

--- a/integration/home.spec.js
+++ b/integration/home.spec.js
@@ -183,25 +183,25 @@ test.describe("at a glance prices", () => {
         await expect(items).toHaveCount(10);
 
         for (let i = 0; i < 10; i++) {
-            expect(items.nth(i).locator("span").nth(0)).toHaveText(/[A-Z]+/);
-            expect(items.nth(i).locator("span").nth(1)).toHaveText(/\$\s*[\d,]+\.\d{2}/)
+            await expect(items.nth(i).locator("span").nth(0)).toHaveText(/[A-Z]+/);
+            await expect(items.nth(i).locator("span").nth(1)).toHaveText(/\$\s*[\d,]+\.\d{2}/)
         }
     })
 });
 
 test.describe("import transactions", () => {
-    test("should allow user to add a transactions from csv", async ({ page }) => {
+    test("should allow user to add transactions from csv", async ({ page }) => {
         await pageSetup({ page });
 
         // since I need to set the file on the input itself in testing, I don't think I need to click the import button
         const importTransactionsButton = page.locator("#add-transactions-button");
         await importTransactionsButton.click();
 
-        const fileInput = page.locator("#csv-file-input");
+        const fileInput = page.locator("#transactions-file-input");
         await fileInput.setInputFiles("./transactions.csv");
 
         // basic verification, that the file was processed and loaded in the modal
-        await expect(page.locator("#review-csv-modal")).toBeVisible();
+        await expect(page.locator("#review-transactions-modal")).toBeVisible();
         await expect(page.locator("tr")).toHaveCount(7);
 
         // submit the transactions and check transaction history list and balance
@@ -210,28 +210,83 @@ test.describe("import transactions", () => {
         await expect(page.locator("#balance-value")).toHaveText(/\$\s*4,497\.74/);
     })
 
-    test("should not allow user to click upload button if errors not fixed", async ({ page }) => {
+    test("should not allow user to click upload button if errors not fixed from csv", async ({ page }) => {
         await pageSetup({ page });
 
-        const fileInput = page.locator("#csv-file-input");
+        const fileInput = page.locator("#transactions-file-input");
         await fileInput.setInputFiles("./bad_transactions.csv");
 
         // basic verification, that the file was processed and loaded in the modal
-        await expect(page.locator("#review-csv-modal")).toBeVisible();
+        await expect(page.locator("#review-transactions-modal")).toBeVisible();
         await expect(page.locator("tr")).toHaveCount(8);
 
         // expect the upload button to be disabled since csv had errors
         await expect(page.locator("#submit-transactions")).toBeDisabled();
     });
 
-    test("should allow user to click upload button after making changes to the appropriate rows", async ({ page }) => {
+    test("should allow user to click upload button after making changes to the appropriate rows (csv import)", async ({ page }) => {
         await pageSetup({ page });
 
-        const fileInput = page.locator("#csv-file-input");
+        const fileInput = page.locator("#transactions-file-input");
         await fileInput.setInputFiles("./bad_transactions.csv");
 
         // basic verification, that the file was processed and loaded in the modal
-        await expect(page.locator("#review-csv-modal")).toBeVisible();
+        await expect(page.locator("#review-transactions-modal")).toBeVisible();
+        await expect(page.locator("tr")).toHaveCount(8);
+
+        // expect the upload button to be disabled since csv had errors
+        await expect(page.locator("#submit-transactions")).toBeDisabled();
+
+        const rows = page.locator("tr");
+        await rows.nth(7).locator("input[name=name]").fill("Test Transaction");
+
+        // the button should now be enabled
+        await expect(page.locator("#submit-transactions")).toBeEnabled();
+
+        // submit the transactions and check transaction history list and balance
+        await page.locator("#submit-transactions").click();
+        await expect(page.locator("#transaction-history-list > *")).toHaveCount(5);
+        await expect(page.locator("#balance-value")).toHaveText(/\$\s*4,507[.]83/);
+    });
+
+    test("should allow user to add transactions from md", async ({ page }) => {
+        await pageSetup({ page });
+
+        const fileInput = page.locator("#transactions-file-input");
+        await fileInput.setInputFiles("./transactions.md");
+
+        // basic verification, that the file was processed and loaded in the modal
+        await expect(page.locator("#review-transactions-modal")).toBeVisible();
+        await expect(page.locator("tr")).toHaveCount(7);
+
+        // submit the transactions and check transaction history list and balance
+        await page.locator("#submit-transactions").click();
+        await expect(page.locator("#transaction-history-list > *")).toHaveCount(5);
+        await expect(page.locator("#balance-value")).toHaveText(/\$\s*4,497\.74/);
+    })
+
+    test("should not allow user to click upload button if errors not fixed from md", async ({ page }) => {
+        await pageSetup({ page });
+
+        const fileInput = page.locator("#transactions-file-input");
+        await fileInput.setInputFiles("./bad_transactions.md");
+
+        // basic verification, that the file was processed and loaded in the modal
+        await expect(page.locator("#review-transactions-modal")).toBeVisible();
+        await expect(page.locator("tr")).toHaveCount(8);
+
+        // expect the upload button to be disabled since csv had errors
+        await expect(page.locator("#submit-transactions")).toBeDisabled();
+    });
+
+    test("should allow user to click upload button after making changes to the appropriate rows (md import)", async ({ page }) => {
+        await pageSetup({ page });
+
+        const fileInput = page.locator("#transactions-file-input");
+        await fileInput.setInputFiles("./bad_transactions.md");
+
+        // basic verification, that the file was processed and loaded in the modal
+        await expect(page.locator("#review-transactions-modal")).toBeVisible();
         await expect(page.locator("tr")).toHaveCount(8);
 
         // expect the upload button to be disabled since csv had errors

--- a/integration/transactions.md
+++ b/integration/transactions.md
@@ -1,0 +1,8 @@
+| name                                    | date       | amount  | assetType | currency | category |
+| --------------------------------------- | ---------- | ------- | --------- | -------- | -------- |
+| Descriptive Deposit Subscription Rebate | 2024-03-02 | 10.00   | cash      | usd      | other    |
+| Descriptive Deposit CC Cashback Rebate  | 2024-03-02 | 6.77    | cash      | usd      | other    |
+| ACH Deposit APPL - EDIPAYMENT           | 2024-03-15 | 2171.45 | cash      | usd      | income   |
+| ACH Deposit IRS TREAS 310 - TAX REF     | 2024-03-27 | 138.00  | cash      | usd      | other    |
+| ACH Deposit APPL - EDIPAYMENT           | 2024-03-29 | 2171.43 | cash      | usd      | income   |
+| Credit Dividend                         | 2024-03-31 | 0.09    | cash      | usd      | other    |

--- a/server/controllers/Transactions.js
+++ b/server/controllers/Transactions.js
@@ -72,7 +72,9 @@ const validateAddTransactionRequest = (reqBody) => {
         return { valid: false, msg: "Asset currency not supported" };
     }
 
-    return { valid: true, name, date, amount, category, assetType: assetType.toLowerCase(), currency: currency.toUpperCase() };
+    // TODO: Please Please make the currencies a common case
+    return { valid: true, name, date, amount, category, assetType: assetType.toLowerCase(),
+        currency: assetType === ASSET_TYPE.CASH ? currency : currency.toUpperCase() };
 }
 
 module.exports.addTransaction = (req , res) => {

--- a/server/routes/transaction.js
+++ b/server/routes/transaction.js
@@ -7,7 +7,10 @@ router
     .post("/", controller.addTransaction)
     .post("/all", controller.addTransactions)
     .post("/csv", controller.processCSV)
+    .post("/md", controller.processMd)
     .get("/export/:format", controller.exportTransactions)
     .get("/all/graph", controller.getGraphData);
+
+// routes POST /, POST /md and POST /csv could probably be consolidated to POST /:format?
 
 module.exports = router;

--- a/server/test/assets/fiveFullGoodTransactions.md
+++ b/server/test/assets/fiveFullGoodTransactions.md
@@ -1,0 +1,7 @@
+| name               | amount | date       | category        | assetType | currency |
+| ------------------ | ------ | ---------- | --------------- | --------- | -------- |
+| Test transaction   | 4      | 2024-04-01 | Investment      | stock     | NVDA     |
+| Test transaction 2 | 760    | 2025-04-02 | Side job        | cash      | USD      |
+| Test transaction 3 | 4      | 2024-04-01 | Smart contracts | crypto    | ETH      |
+| Test transaction 4 | .3     | 2024-05-01 |                 | crypto    | BTC      |
+| Test transaction 5 | 50     | 2024-08-01 |                 | crypto    | ADA      |

--- a/server/test/assets/fiveGoodTransactions.md
+++ b/server/test/assets/fiveGoodTransactions.md
@@ -1,0 +1,7 @@
+| date       | name               |  currency | amount | assetType |
+| ---------- | ------------------ | --------- | ------ | --------- |
+| 2024-04-01 | Test transaction   | NVDA      | 4      | stock     |
+| 2025-04-02 | Test transaction 2 | USD       | 760    | cash      |
+| 2024-04-01 | Test transaction 3 | ETH       | 4      | crypto    |
+| 2024-05-01 | Test transaction 4 | BTC       | 0.3    | crypto    |
+| 2024-08-01 | Test transaction 5 | ADA       | 50     | crypto    |

--- a/server/test/assets/missingHeaderFieldsTransactions.csv
+++ b/server/test/assets/missingHeaderFieldsTransactions.csv
@@ -1,6 +1,6 @@
-name,type,date,category,assetType
-Test transaction,true,2024-04-01,Investment,stock
-Test transaction 2,true,2025-04-02,Side job,cash
-Test transaction 3,true,2024-04-01,Smart contracts,crypto
-Test transaction 4,true,2024-05-01,,crypto
-Test transaction 5,true,2024-08-01,,crypto
+name,date,category,assetType
+Test transaction,2024-04-01,Investment,stock
+Test transaction 2,2025-04-02,Side job,cash
+Test transaction 3,2024-04-01,Smart contracts,crypto
+Test transaction 4,2024-05-01,,crypto
+Test transaction 5,2024-08-01,,crypto

--- a/server/test/assets/missingHeaderFieldsTransactions.md
+++ b/server/test/assets/missingHeaderFieldsTransactions.md
@@ -1,0 +1,7 @@
+| Name               | Date       | Category        | Asset Type |
+| ------------------ | ---------- | --------------- | ---------- |
+| Test transaction   | 2024-04-01 | Investment      | stock      |
+| Test transaction 2 | 2025-04-02 | Side job        | cash       |
+| Test transaction 3 | 2024-04-01 | Smart contracts | crypto     |
+| Test transaction 4 | 2024-05-01 |                 | crypto     |
+| Test transaction 5 | 2024-08-01 |                 | crypto     |

--- a/server/test/assets/missingRequiredFieldsTransactions.md
+++ b/server/test/assets/missingRequiredFieldsTransactions.md
@@ -1,0 +1,9 @@
+Date       | Name               | Currency | Amount | Category   | AssetType
+-----------|--------------------|----------|--------|------------|----------
+2024-04-01 | Test transaction   | NVDA     | 4      | Investment |
+2025-04-02 | Test transaction 2 | USD      | 760    | Other      | cash
+2024-04-01 | Test transaction 3 | ETH      | 4      | Other      | crypto
+2024-05-01 | Test transaction 4 | BTC      |        |            | crypto
+2024-08-01 | Test transaction 5 | ADA      | 50     |            | crypto
+2024-08-01 |                    | ADA      | 50     |            | crypto
+2024-08-01 | ADA                | 50       |        | crypto

--- a/server/test/controllers/transaction.spec.js
+++ b/server/test/controllers/transaction.spec.js
@@ -1,5 +1,5 @@
 const { describe, expect, test } = require("@jest/globals");
-const { validateAddTransactionRequest, expectedCsvHeader, csv } = require("../../controllers/Transactions");
+const { validateAddTransactionRequest, expectedCsvHeader, csv, md } = require("../../controllers/Transactions");
 const { isNumber } = require("../../utils/utils");
 
 describe("Transactions", () => {
@@ -94,6 +94,18 @@ describe("Transactions", () => {
             const expected = /Name,Amount,Date,Category,Asset Type,Currency\nTest,50,\d{4}-\d{2}-\d{2} \d{2}:\d{2},Groceries,cash,USD/;
 
             expect(csv(input)).toMatch(expected);
+        });
+    });
+
+    describe("md", () => {
+        test("should return markdown table for provided json transactions", () => {
+            const input = [{ name: "Test", amount: 50, type: true, date: 1640995200000, category: "Groceries", assetType: "cash", currency: "USD" }];
+            const header = "| Name | Amount | Date             | Category  | Asset Type | Currency |";
+            const headerSeparator = "| ---- | ------ | ---------------- | --------- | ---------- | -------- |";
+            const body = "| Test | 50     | \d{4}-\d{2}-\d{2} \d{2}:\d{2} | Groceries | cash       | USD      |"
+            const expected = new RegExp(header + "\n" + headerSeparator + "\n" + body);
+
+            expect(md(input)).toMatch(expected);
         });
     });
 });

--- a/server/test/controllers/transaction.spec.js
+++ b/server/test/controllers/transaction.spec.js
@@ -1,5 +1,5 @@
 const { describe, expect, test } = require("@jest/globals");
-const { validateAddTransactionRequest, expectedCsvHeader, csv, md } = require("../../controllers/Transactions");
+const { validateAddTransactionRequest, expectedHeader, csv, md } = require("../../controllers/Transactions");
 const { isNumber } = require("../../utils/utils");
 
 describe("Transactions", () => {
@@ -56,7 +56,7 @@ describe("Transactions", () => {
         });
     });
 
-    describe("expectedCsvHeader", () => {
+    describe("expectedHeader", () => {
         const invalidCsvHeaders = [
             { input: "", expected: { valid: false, missingFields: ["name", "amount", "date", "category", "assettype", "currency"] } },
             { input: "name", expected: { valid: false, missingFields: ["amount", "date", "category", "assettype", "currency"] } },
@@ -66,6 +66,20 @@ describe("Transactions", () => {
             { input: "name,date,amount,category,assetType", expected: { valid: false, missingFields: ["currency"] } },
         ];
 
+        const invalidMdHeaders = [
+            { input: "", expected: { valid: false, missingFields: ["name", "amount", "date", "category", "assettype", "currency"] } },
+            { input: "name", expected: { valid: false, missingFields: ["amount", "date", "category", "assettype", "currency"] } },
+            { input: "|name|", expected: { valid: false, missingFields: ["amount", "date", "category", "assettype", "currency"] } },
+            { input: "name|amount", expected: { valid: false, missingFields: ["date", "category", "assettype", "currency"] } },
+            { input: "|name|amount|", expected: { valid: false, missingFields: ["date", "category", "assettype", "currency"] } },
+            { input: "name|date|amount", expected: { valid: false, missingFields: ["category", "assettype", "currency"] } },
+            { input: "|name|date|amount|", expected: { valid: false, missingFields: ["category", "assettype", "currency"] } },
+            { input: "name|date|amount|category", expected: { valid: false, missingFields: ["assettype", "currency"] } },
+            { input: "|name|date|amount|category|", expected: { valid: false, missingFields: ["assettype", "currency"] } },
+            { input: "name|date|amount|category|assetType", expected: { valid: false, missingFields: ["currency"] } },
+            { input: "|name|date|amount|category|assetType|", expected: { valid: false, missingFields: ["currency"] } },
+        ];
+
         const validCsvHeaders = [
             { input: "name,date,amount,category,currency,assetType",
                 expected: { valid: true, map: { name: 0, date: 1, amount: 2, category: 3, assettype: 5, currency: 4 } } },
@@ -73,18 +87,43 @@ describe("Transactions", () => {
                 expected: { valid: true, map: { name: 1, date: 2, amount: 3, category: 5, assettype: 4, currency: 0 } } },
             { input: "name,amount,currency,category,assettype,date",
                 expected: { valid: true, map: { name: 0, date: 5, amount: 1, category: 3, assettype: 4, currency: 2 } } },
-            { input: "name,amount,currency,category,assettype,date",
-                expected: { valid: true, map: { name: 0, date: 5, amount: 1, category: 3, assettype: 4, currency: 2 } } },
             { input: "name,amount,currency,assettype,date",
                 expected: { valid: true, map: { name: 0, date: 4, amount: 1, category: null, assettype: 3, currency: 2 } } }
         ];
 
+        const validMdHeaders = [
+            { input: "name|date|amount|category|currency|assetType",
+                expected: { valid: true, map: { name: 0, date: 1, amount: 2, category: 3, assettype: 5, currency: 4 } } },
+            { input: "|name|date|amount|category|currency|assetType|",
+                expected: { valid: true, map: { name: 1, date: 2, amount: 3, category: 4, assettype: 6, currency: 5 } } },
+            { input: "currency|name|date|amount|assetType|category",
+                expected: { valid: true, map: { name: 1, date: 2, amount: 3, category: 5, assettype: 4, currency: 0 } } },
+            { input: "|currency|name|date|amount|assetType|category|",
+                expected: { valid: true, map: { name: 2, date: 3, amount: 4, category: 6, assettype: 5, currency: 1 } } },
+            { input: "name|amount|currency|category|assettype|date",
+                expected: { valid: true, map: { name: 0, date: 5, amount: 1, category: 3, assettype: 4, currency: 2 } } },
+            { input: "|name|amount|currency|category|assettype|date|",
+                expected: { valid: true, map: { name: 1, date: 6, amount: 2, category: 4, assettype: 5, currency: 3 } } },
+            { input: "name|amount|currency|assettype|date",
+                expected: { valid: true, map: { name: 0, date: 4, amount: 1, category: null, assettype: 3, currency: 2 } } },
+            { input: "|name|amount|currency|assettype|date|",
+                expected: { valid: true, map: { name: 1, date: 5, amount: 2, category: null, assettype: 4, currency: 3 } } }
+        ];
+
         test.each(invalidCsvHeaders)("should return false for invalid csv headers: '%s'", ({ input, expected }) => {
-            expect(expectedCsvHeader(input)).toEqual(expected);
+            expect(expectedHeader(input, ",")).toEqual(expected);
         });
 
-        test.each(validCsvHeaders)("should return true for valid transaction payloads: %s", ({ input, expected }) => {
-            expect(expectedCsvHeader(input)).toEqual(expected);
+        test.each(invalidMdHeaders)("should return false for invalid markdown table headers: '%s'", ({ input, expected }) => {
+            expect(expectedHeader(input, "|")).toEqual(expected);
+        });
+
+        test.each(validCsvHeaders)("should return true for valid csv transaction payloads: %s", ({ input, expected }) => {
+            expect(expectedHeader(input, ",")).toEqual(expected);
+        });
+
+        test.each(validMdHeaders)("should return true for valid md transaction payloads: %s", ({ input, expected }) => {
+            expect(expectedHeader(input, "|")).toEqual(expected);
         });
     });
 

--- a/server/test/utils/utils.spec.js
+++ b/server/test/utils/utils.spec.js
@@ -1,7 +1,7 @@
 const { describe, expect, test } = require("@jest/globals");
 
 const { isNumber, makeBool, isDefined, isValidArray, positiveNumberOrZero, toPrecision,
-    formatDate, pad, isValidString } = require("../../utils/utils");
+    formatDate, pad, isValidString, padRight } = require("../../utils/utils");
 
 describe("utils", () => {
     describe("isNumber", () => {
@@ -188,6 +188,24 @@ describe("utils", () => {
 
         test.each(testCases)("should pad string with zeros until length reaches n: '%s'", ({ input, n, expected }) => {
             expect(pad(input, n)).toBe(expected);
+        });
+    });
+
+    describe("padRight", () => {
+        const testCases = [
+            { input: 123, n: 2, c: "-", expected: "123" },
+            { input: 1, n: 3, c: "-", expected: "1--" },
+            { input: "abcde", n: 2, c: " ", expected: "abcde" },
+            { input: "1234", n: 5, c: " ", expected: "1234 " },
+            { input: " 1", n: 2, c: " ", expected: " 1" },
+            { input: "1 ", n: 2, c: " ", expected: "1 " },
+            { input: "1 ", n: 3, c: " ", expected: "1  " },
+            { input: "1", n: 2, c: " ", expected: "1 " },
+            { input: "1", n: 3, c: "-", expected: "1--" },
+        ];
+
+        test.each(testCases)("should pad string on the right with desired character until length reaches n: '%s'", ({ input, n, c, expected }) => {
+            expect(padRight(input, n, c)).toBe(expected);
         });
     });
 

--- a/server/test_integration/transaction.test.js
+++ b/server/test_integration/transaction.test.js
@@ -347,6 +347,110 @@ describe("transaction endpoints", () => {
         });
     });
 
+    describe("processMd", () => {
+        test.each([
+            { payload: "", msg: "payload cannot be empty" },
+            { payload: " ", msg: "payload cannot be empty" },
+            { payload: null, msg: "You need to provide a valid markdown table" },
+            { payload: undefined, msg: "You need to provide a valid markdown table" },
+            { payload: 23, msg: "payload must be a string" },
+            { payload: { amount: 23, name: "Test Transaction" }, msg: "payload must be a string" },
+            { payload: "| Name | Amount | Date |", msg: "invalid markdown format detected" }
+        ])("should return bad request when no data / invalid data is provided: %s", async ({ payload, msg }) => {
+            // Act
+            const response = await superTestRequest.post("/api/transaction/md").send({ md: payload });
+
+            // Assert
+            expect(response.status).toBe(400);
+            expect(response.body.msg).toEqual(msg);
+        });
+
+        test("should return bad request when only the markdown table header is provided", async () => {
+            // Act
+            const response = await superTestRequest.post("/api/transaction/md")
+                .send({ md: "| Name | Amount | Date |\n| ---- | ----- | ----- |" });
+
+            // Assert
+            expect(response.status).toBe(400);
+            expect(response.body.msg).toEqual("Expected at least one markdown table row along with the headers");
+        });
+
+        // TODO: update this test when I start to use AI
+        test("should return bad request when header is missing required fields", async () => {
+            // Arrange
+            const data = fs.readFileSync("./test/assets/missingHeaderFieldsTransactions.md", "utf-8");
+
+            // Act
+            const response = await superTestRequest.post("/api/transaction/md").send({ md: data });
+
+            // Assert
+            expect(response.status).toBe(400);
+            expect(response.body.msg).toEqual("Invalid markdown table header, missing fields: amount,currency");
+        });
+
+        test("should return bad request when transaction are missing required fields", async () => {
+            // Arrange
+            const data = fs.readFileSync("./test/assets/missingRequiredFieldsTransactions.md", "utf-8");
+
+            // Act
+            const response = await superTestRequest.post("/api/transaction/md").send({ md: data });
+
+            // Assert
+            expect(response.status).toBe(400);
+            expect(response.body.msg).toEqual("Invalid markdown table");
+            expect(response.body.invalid).toEqual({
+                0: "You need to have a valid transaction asset type",
+                3: "You need to have the transaction amount",
+                5: "You need to have the transaction name",
+                6: "You need to have the transaction amount",
+            });
+        });
+
+        test("should return successful response with interpreted transactions when markdown table contains all expected fields", async () => {
+            // Arrange
+            const data = fs.readFileSync("./test/assets/fiveFullGoodTransactions.md", "utf-8");
+
+            // Act
+            const response = await superTestRequest.post("/api/transaction/md").send({ md: data });
+
+            // Assert
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual("Markdown table processed successfully");
+            expect(response.body.transactions).toEqual([
+                { amount: 4, assetType: "stock", category: "Investment", currency: "NVDA",
+                    date: 1711929600000, name: "Test transaction", valid: true },
+                { amount: 760, assetType: "cash", category: "Side job", currency: "USD",
+                    date: 1743552000000, name: "Test transaction 2", valid: true },
+                { amount: 4, assetType: "crypto", category: "Smart contracts", currency: "ETH",
+                    date: 1711929600000, name: "Test transaction 3", valid: true },
+                { amount: 0.3, assetType: "crypto", category: "", currency: "BTC",
+                    date: 1714521600000, name: "Test transaction 4", valid: true },
+                { amount: 50, assetType: "crypto", category: "", currency: "ADA",
+                    date: 1722470400000, name: "Test transaction 5", valid: true }
+            ]);
+        });
+
+        test("should return successful response with interpreted transactions when table contains all expected fields (except category)",async () =>{
+            // Arrange
+            const data = fs.readFileSync("./test/assets/fiveGoodTransactions.md", "utf-8");
+
+            // Act
+            const response = await superTestRequest.post("/api/transaction/md").send({ md: data });
+
+            // Assert
+            expect(response.status).toBe(200);
+            expect(response.body.msg).toEqual("Markdown table processed successfully");
+            expect(response.body.transactions).toEqual([
+                { amount: 4, assetType: "stock", category: "other", currency: "NVDA", date: 1711929600000, name: "Test transaction", valid: true },
+                { amount: 760, assetType: "cash", category: "other", currency: "USD", date: 1743552000000, name: "Test transaction 2", valid: true },
+                { amount: 4, assetType: "crypto", category: "other", currency: "ETH", date: 1711929600000, name: "Test transaction 3", valid: true },
+                { amount: 0.3, assetType: "crypto", category: "other", currency: "BTC", date: 1714521600000,
+                    name: "Test transaction 4", valid: true },
+                { amount: 50, assetType: "crypto", category: "other", currency: "ADA", date: 1722470400000, name: "Test transaction 5", valid: true }
+            ]);
+        });
+    });
+
     describe("exportTransactions", () => {
         test("should return bad request when an invalid format is provided", async () => {
             // Act

--- a/server/test_integration/transaction.test.js
+++ b/server/test_integration/transaction.test.js
@@ -357,7 +357,7 @@ describe("transaction endpoints", () => {
             expect(response.body.msg).toBe("Invalid export format");
         });
 
-        test("should return success response and all transactions as json when transactions added successfully", async () => {
+        test("should return success response and all transactions as json when transactions exist", async () => {
             // Arrange
             await superTestRequest.post("/api/transaction/all").send([
                 { name: "Test cash transaction", amount: 100, assetType: "cash", currency: "usd", date: "2022-01-01", category: "Groceries" },
@@ -373,7 +373,7 @@ describe("transaction endpoints", () => {
             expect(response.body.length).toBe(3);
         });
 
-        test("should return success response and all transactions as csv when transactions added successfully", async () => {
+        test("should return success response and all transactions as csv when transactions exist", async () => {
             // Arrange
             await superTestRequest.post("/api/transaction/all").send([
                 { name: "Test cash transaction", amount: 100, assetType: "cash", currency: "usd", date: "2022-01-01", category: "Groceries" },
@@ -387,6 +387,22 @@ describe("transaction endpoints", () => {
             // Assert
             expect(response.status).toBe(200);
             expect(response.body.csv.split("\n").length).toBe(4);
+        });
+
+        test("should return success response and all transactions as a markdown table when transactions exist", async () => {
+            // Arrange
+            await superTestRequest.post("/api/transaction/all").send([
+                { name: "Test cash transaction", amount: 100, assetType: "cash", currency: "usd", date: "2022-01-01", category: "Groceries" },
+                { name: "Test crypto transaction", amount: -1, assetType: "crypto", currency: "btc", date: "2023-01-01" },
+                { name: "Test stock transaction", amount: 5.2, assetType: "stock", currency: "AAPL", category: "Investment", date: "2024-01-01" }
+            ]);
+
+            // Act
+            const response = await superTestRequest.get("/api/transaction/export/md");
+
+            // Assert
+            expect(response.status).toBe(200);
+            expect(response.body.md.split("\n").length).toBe(5);
         });
     });
 });

--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -69,6 +69,22 @@ const pad = (v, n = 2) => {
     return v;
 };
 
+// TODO: write tests
+const padRight = (v, n, c) => {
+    v = v + ""; // convert to string
+    if (v.length >= n) {
+        return v;
+    }
+
+    for (let i = 0; i < n; i++) {
+        v = v + c;
+        if (v.length >= n) {
+            break;
+        }
+    }
+    return v;
+}
+
 const formatDate = (d) => {
     if (typeof d === "string") {
         d = d.trim();
@@ -154,4 +170,4 @@ const request = ({ site, port, path, method="POST", body="", headers={} }) => {
 };
 
 module.exports = { isNumber, request, sleep, makeBool, isDefined, format, isValidArray,
-    positiveNumberOrZero, toPrecision, formatDate, pad, isValidString };
+    positiveNumberOrZero, toPrecision, formatDate, pad, isValidString, padRight };


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] Searched for similar existing [pull requests](https://github.com/JChris246/financial_tracker/pulls)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] Covered the code with tests that prove my fix is effective or that my feature works (note that PRs
without tests will likely be REJECTED)
- [x] New and existing tests pass locally with my changes

---

### What is the purpose of your *pull request*?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of your *pull request* and other information

This PR builds on the import functionality of importing transactions from csv files and allows import from markdown tables. Closes #8. This PR also deprecates the use of the transaction type field.

## How Has This Been Tested?

Automation tests were added. 

Manual test:

- run the app development mode
- navigate to the home page and click the existing import button
- select a local md containing (only) a markdown table of transactions
- fix any errors in the review modal
- click the import button


Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

## Screenshots (if appropriate):