### PR TITLE
[Feature] allow user to specify their monthly income in amortization calculator

### DIFF
--- a/client/src/Calculators.jsx
+++ b/client/src/Calculators.jsx
@@ -346,7 +346,7 @@ function Calculators() {
                 down: amortizationCalculatorData.deposit,
                 interest: amortizationCalculatorData.rate / 100,
                 price: amortizationCalculatorData.price,
-                months: amortizationCalculatorData.period,
+                months: amortizationCalculatorData.period
             }),
             callback: ({ msg, success, json }) => {
                 if (success) {
@@ -356,7 +356,7 @@ function Calculators() {
                         history: json.history,
                         loanAmount: json.loanAmount,
                         monthly: json.monthly,
-                        totalPaid: json.totalPaid
+                        totalPaid: json.totalPaid,
                     });
                     setAmortizationPie({
                         datasets: [{
@@ -393,6 +393,11 @@ function Calculators() {
                 }
             }
         });
+
+        if (amortizationCalculatorData.monthlyIncome && amortizationCalculatorData.monthlyIncome !== 0) {
+            setIncome(amortizationCalculatorData.monthlyIncome);
+            return;
+        }
 
         const sixMonths = 1000 * 60 * 60 * 24 * 30 * 6;
         const from = formatDate(new Date(new Date().getTime() - sixMonths), DATE_TYPE.DISPLAY_DATE);
@@ -824,7 +829,6 @@ function Calculators() {
                             </div>
                         </div>
 
-                        {/* TODO: add a input to allow user to add their real monthly income */}
                         <div className="mb-4 w-full md:w-3/4 mx-auto">
                             <label for="amortization-deposit">Deposit</label>
                             <div className="relative mt-2">
@@ -835,6 +839,19 @@ function Calculators() {
                                     className="pl-5 pr-4 py-2 border rounded-md bg-gray-800 text-gray-300 border-gray-600
                                         focus:border-blue-500 focus:outline-none focus:ring w-full"
                                     title="amortization deposit" />
+                            </div>
+                        </div>
+
+                        <div className="mb-4 w-full md:w-3/4 mx-auto">
+                            <label for="amortization-monthly-income">Monthly Income (Optional)</label>
+                            <div className="relative mt-2">
+                                <label className="absolute top-2 left-2">$</label>
+                                <input
+                                    type="number" value={amortizationCalculatorData.monthlyIncome} onChange={enterAmortizationCalculatorData}
+                                    name="monthlyIncome" id="amortization-monthly-income" step={50} min={0}
+                                    className="pl-5 pr-4 py-2 border rounded-md bg-gray-800 text-gray-300 border-gray-600
+                                        focus:border-blue-500 focus:outline-none focus:ring w-full"
+                                    title="monthly income" />
                             </div>
                         </div>
 

--- a/integration/calculators.spec.js
+++ b/integration/calculators.spec.js
@@ -364,4 +364,28 @@ test.describe("amortization calculator", () => {
         await expect(historyTable.locator("tr").nth(1).locator("td").last()).toHaveText("44,387.56");
         await expect(historyTable.locator("tr").last().locator("td").last()).toHaveText("0.00");
     });
+
+    test("should allow calculating amortization with a deposit and monthly income", async ({ page }) => {
+        await pageSetup({ page, pathname: "/calculators" });
+
+        await page.locator("#amortization-price").fill("40000");
+        await page.locator("#amortization-deposit").fill("15000");
+        await page.locator("#amortization-monthly-income").fill("6434.49");
+        await page.locator("#amortization-period").fill("36");
+        await page.locator("#amortization-rate").fill("8");
+
+        await page.locator("#calculate-amortization").click();
+
+        await expect(page.locator("#risk-text")).toBeVisible();
+        await expect(page.locator("#risk-text")).toHaveText("Safe");
+        await expect(page.locator("#total-total-paid")).toHaveText("$43,202.73");
+
+        await page.locator("#amortization-table-tab").click();
+        const historyTable = page.locator("#amortization-table");
+        await expect(historyTable).toBeVisible();
+
+        await expect(historyTable.locator("tr")).toHaveCount(37);
+        await expect(historyTable.locator("tr").nth(1).locator("td").last()).toHaveText("24,383.26");
+        await expect(historyTable.locator("tr").last().locator("td").last()).toHaveText("0.00");
+    });
 });


### PR DESCRIPTION
### Before submitting a *pull request* make sure you have:
- [x] Searched for similar existing [pull requests](https://github.com/JChris246/financial_tracker/pulls)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] Covered the code with tests that prove my fix is effective or that my feature works (note that PRs
without tests will likely be REJECTED)
- [x] New and existing tests pass locally with my changes

---

### What is the purpose of your *pull request*?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Description of your *pull request* and other information

This PR adds a new input box on the amortization calculator to allow users to specify their monthly income. This value is factored into the risk message that is displayed based on the monthly payment vs monthly income. 

## How Has This Been Tested?

Automation tests were added.

Manual testing:

- Navigate to the calculators page
- Find the Amortization calculator and fill in the values appropriately
- Click the calculate button

You should see the results in the form of a table, pie and line chart as well as the entered monthly income in the result summary.

## Screenshots (if appropriate):

<img width="1996" height="1026" alt="image" src="https://github.com/user-attachments/assets/2a3d2ef9-dae3-44c0-be60-4d39de6d9b92" />
